### PR TITLE
Fixes #33

### DIFF
--- a/resources/views/cropper.blade.php
+++ b/resources/views/cropper.blade.php
@@ -5,9 +5,9 @@
         @include('admin::form.error')
         <div class="btn btn-info pull-left cropper-btn">{{ trans('admin_cropper.choose') }}</div>
         @include('admin::form.help-block')
-        <input class="cropper-file" type="file" accept="image/*" {!! $attributes !!}/>
+        <input class="cropper-file" type="file" accept="image/*"/>
         <!-- <img class="cropper-img" {!! empty($value) ? '' : 'src="'.old($column, $value).'"'  !!}> -->
         <img class="cropper-img" {!! empty($value) ? '' : 'src="'.$preview.'"'  !!}>
-        <input class="cropper-input" name="{{$name}}" value="{{ old($column, $value) }}"/>
+        <input class="cropper-input" name="{{$name}}" value="{{ old($column, $value) }}" {!! $attributes !!}/>
     </div>
 </div>


### PR DESCRIPTION
With required attribute in .cropper-file, form unable to submit. Swapping attribute from .cropper-file to .cropper-input probably fixes this issue.